### PR TITLE
Bumped version to 1.7.1 and detailed setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ More information about the Java API and TorchScript:
 - [PyTorch-style JavaDoc](https://pytorch.org/docs/stable/packages.html)
 - [Standard JavaDoc](https://pytorch.org/javadoc/1.4.0/)
 - [PyTorch Android tutorial](https://pytorch.org/mobile/android/)
+
+### Example Setup for macOS with v 1.7.1
+
+``` sh
+cd ~/code/java
+wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.7.1.zip
+unzip libtorch-macos-1.7.1.zip
+export LIBTORCH_HOME="~/code/java/libtorch"
+export USE_LIBTORCH_NIGHTLY=1
+export JAVA_HOME=$(/usr/libexec/java_home)
+./gradlew run
+```

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 def USE_NIGHTLY = System.getenv('USE_LIBTORCH_NIGHTLY')?.toBoolean()
 
-def LIBTORCH_VERSION = USE_NIGHTLY ? "1.7.0-SNAPSHOT" : "1.6.0";
+def LIBTORCH_VERSION = USE_NIGHTLY ? "1.7.1" : "1.6.0";
 
 repositories {
     jcenter()


### PR DESCRIPTION
I had problems trying to install and run java-demo in December 2020.

The PyTorch version used in Gradle script was out of date; updated it from 1.7.0-SNAPSHOT to 1.7.1.

I also added a little more details to setup instructions.
